### PR TITLE
Fix import paths for pipeline functions

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,10 +21,13 @@ from utils.feature_utils import save_config
 
 from clustering import (
     prepare_clustered_dataset,
-    main_matching_pipeline,
-    plot_prediction_uncertainty_with_contours,
     compute_cluster_summary,
     compute_pv_potential_by_cluster_year,
+)
+
+from pv_prediction import (
+    main_matching_pipeline,
+    plot_prediction_uncertainty_with_contours,
     prepare_features_for_clustering,
 )
 

--- a/multi_year_controller(not needed).py
+++ b/multi_year_controller(not needed).py
@@ -1,6 +1,6 @@
 import os
 import logging
-from clustering import main_matching_pipeline
+from pv_prediction import main_matching_pipeline
 import pandas as pd
 from utils.feature_utils import save_config
 from config import get_path


### PR DESCRIPTION
## Summary
- import key pipeline functions from `pv_prediction`
- update multi-year controller

## Testing
- `pytest -q` *(fails: FileNotFoundError in pv_potential, ModuleNotFoundError for database_utils)*

------
https://chatgpt.com/codex/tasks/task_e_6863f5a350288331a3a05db2d0bd443a