### PR TITLE
Use shared sigma constant

### DIFF
--- a/RC_Clustering.py
+++ b/RC_Clustering.py
@@ -10,6 +10,9 @@ from sklearn.metrics import silhouette_score
 import os
 from config import get_column, get_path
 from utils.sky_temperature import calculate_sky_temperature_improved
+from constants import ATMOSPHERIC_CONSTANTS
+
+SIGMA_SB = ATMOSPHERIC_CONSTANTS['sigma_sb']
 
 def rc_only_clustering(df, features=None, n_clusters=5, cluster_col='RC_Cluster', model_path=None):
     """
@@ -157,7 +160,7 @@ def calculate_rc_power_improved(df, albedo=0.3, emissivity=0.95):
     T_sky = calculate_sky_temperature_improved(df[t_air_col], RH, TCC)
 
     # Radiative cooling model
-    σ = 5.67e-8  # W/m²·K⁴
+    σ = SIGMA_SB
     T_air_K = df[t_air_col] + 273.15
     T_sky_K = T_sky + 273.15
 

--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ import io
 import zipfile
 import warnings
 warnings.filterwarnings('ignore')
+from constants import ATMOSPHERIC_CONSTANTS
 
 
 def parse_args():
@@ -90,7 +91,7 @@ def compute_temperature_series(ghi, tair, ir_down, wind, zenith, material_config
     Q_solar = alpha * ghi * cos_zenith
     
     # Radiative cooling to sky (simplified)
-    sigma = 5.67e-8  # Stefan-Boltzmann constant
+    sigma = ATMOSPHERIC_CONSTANTS['sigma_sb']
     # Estimate effective sky temperature from downwelling IR
     T_sky = (ir_down / (epsilon * sigma)) ** 0.25
     

--- a/enhanced_thermal_model.py
+++ b/enhanced_thermal_model.py
@@ -10,6 +10,7 @@ from pv_profiles import RC_MATERIALS
 import xarray as xr
 import numpy as np
 from pv_profiles import PV_CONSTANTS
+from constants import ATMOSPHERIC_CONSTANTS
 
 # Optional: config connection
 try:
@@ -18,7 +19,7 @@ except ImportError:
     get_config = None  # fallback if you want to run standalone
 
 # Stefan–Boltzmann constant
-SIGMA = 5.670374419e-8  # W/m²·K⁴
+SIGMA = ATMOSPHERIC_CONSTANTS['sigma_sb']  # W/m²·K⁴
 SELECTED_MATERIAL = "Smart_Coating"
 material_config = RC_MATERIALS[SELECTED_MATERIAL]
 

--- a/rc_climate_zoning.py
+++ b/rc_climate_zoning.py
@@ -7,13 +7,15 @@ from sklearn_extra.cluster import KMedoids
 import matplotlib.pyplot as plt
 import geopandas as gpd
 import contextily as ctx
-from scipy.constants import sigma as σ
+from constants import ATMOSPHERIC_CONSTANTS
 import joblib
 import os
 from sklearn.metrics import silhouette_score
 from config import get_path
 import xarray as xr
 import rasterio
+
+σ = ATMOSPHERIC_CONSTANTS['sigma_sb']
 
 from utils.sky_temperature import calculate_sky_temperature_improved
 

--- a/rc_cooling_combined_2025.py
+++ b/rc_cooling_combined_2025.py
@@ -29,7 +29,7 @@ logging.basicConfig(level=logging.INFO,
 ##############################################################################
 #                               CONFIGURATION
 ##############################################################################
-STEFAN_BOLTZMANN = 5.67e-8      # W/m²/K^4
+STEFAN_BOLTZMANN = ATMOSPHERIC_CONSTANTS['sigma_sb']  # W/m²/K^4
 DEFAULT_RHO       = 0.2         # Default solar reflectivity
 DEFAULT_EPS_COAT  = 0.95        # Assumed IR emissivity of the coating
 CHUNK_SIZE        = 10000       # Number of rows per CSV chunk
@@ -476,7 +476,7 @@ def estimate_sky_temperature_hybrid(df):
     e_sky = 0.6 + 0.2 * df['tcc'] + 0.002 * RH
     e_sky = np.clip(e_sky, 0.7, 1.0)
 
-    sigma = 5.670374419e-8  # Stefan–Boltzmann constant
+    sigma = ATMOSPHERIC_CONSTANTS['sigma_sb']  # Stefan–Boltzmann constant
     IR_down = df['msdwlwrf']  # W/m²
 
     T_sky_K = (IR_down / (e_sky * sigma)) ** 0.25


### PR DESCRIPTION
## Summary
- use `ATMOSPHERIC_CONSTANTS['sigma_sb']` everywhere instead of local copies
- update cooling modules to rely on this shared constant

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'get_grib_dir' from 'config')*

------
https://chatgpt.com/codex/tasks/task_e_6864eb46cb208331a6b865d7ba4dcf71