### PR TITLE
Remove unused convert_xarray_to_dataframe import

### DIFF
--- a/pv_prediction.py
+++ b/pv_prediction.py
@@ -22,7 +22,6 @@ from xgboost import XGBRegressor
 import logging
 from pv_profiles import pv_profiles as default_pv_profiles
 import argparse
-from utils.feature_utils import convert_xarray_to_dataframe
 from utils.feature_utils import (
     compute_band_ratios,
     filter_valid_columns,


### PR DESCRIPTION
## Summary
- remove unused `convert_xarray_to_dataframe` import from `pv_prediction.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686505a2ceec8331bb707fcf0c12de39