### PR TITLE
Use logging for pvlib fallback message

### DIFF
--- a/dynamic_materials.py
+++ b/dynamic_materials.py
@@ -11,13 +11,14 @@ Improved version:
 
 import numpy as np
 import pandas as pd
+import logging
 
 try:
     from pvlib.solarposition import get_solarposition
     PVLIB_AVAILABLE = True
 except ImportError:
     PVLIB_AVAILABLE = False
-    print("⚠️ pvlib not available — using fallback zenith logic.")
+    logging.warning("⚠️ pvlib not available — using fallback zenith logic.")
 
 
 def get_material_state(


### PR DESCRIPTION
## Summary
- use `logging.warning` instead of `print` when pvlib is missing

## Testing
- `pytest -q` *(fails: cannot import name 'get_grib_dir')*

------
https://chatgpt.com/codex/tasks/task_e_686505a1c24883319cfa3d9e92f86d79