### PR TITLE
Fix redundant config import

### DIFF
--- a/RC_Clustering.py
+++ b/RC_Clustering.py
@@ -5,7 +5,6 @@ import geopandas as gpd
 import matplotlib.pyplot as plt
 import joblib
 import contextily as ctx
-from config import get_path
 from constants import ATMOSPHERIC_CONSTANTS
 
 SIGMA_SB = ATMOSPHERIC_CONSTANTS["sigma_sb"]


### PR DESCRIPTION
## Summary
- deduplicate config imports in `RC_Clustering.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: cannot import name 'get_grib_dir')*

------
https://chatgpt.com/codex/tasks/task_e_686505a236c48331821a3a663c8d78a1