### PR TITLE
Add xarray to dataframe helper

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -9,6 +9,7 @@ from .feature_utils import (
     spectral_summary,
     filter_valid_columns,
     compute_cluster_spectra,
+    convert_xarray_to_dataframe,
     save_config,
 )
 
@@ -23,5 +24,6 @@ __all__ = [
     "spectral_summary",
     "filter_valid_columns",
     "compute_cluster_spectra",
+    "convert_xarray_to_dataframe",
     "save_config",
 ]

--- a/utils/feature_utils.py
+++ b/utils/feature_utils.py
@@ -3,6 +3,8 @@ import logging
 from datetime import datetime
 from typing import List, Tuple
 
+import xarray as xr
+
 import numpy as np
 import pandas as pd
 import yaml
@@ -91,3 +93,19 @@ def save_config(config: dict, output_dir: str) -> str:
         yaml.dump(config, f)
     logging.info(f"Saved configuration to {path}")
     return path
+
+
+def convert_xarray_to_dataframe(ds: xr.Dataset) -> pd.DataFrame:
+    """Flatten an ``xarray.Dataset`` to a ``pandas.DataFrame``.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Input dataset.
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataset converted to a DataFrame with reset index.
+    """
+    return ds.to_dataframe().reset_index()


### PR DESCRIPTION
## Summary
- implement `convert_xarray_to_dataframe` in `utils/feature_utils`
- expose helper in `utils.__init__`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'get_grib_dir' from 'config')*

------
https://chatgpt.com/codex/tasks/task_e_6865059f1be883319896a5504be6daf5